### PR TITLE
Add pragmatic difference between `email` and `corespondence`

### DIFF
--- a/filters/assimilateMetadata.rb
+++ b/filters/assimilateMetadata.rb
@@ -92,9 +92,9 @@ Paru::Filter.run do
 
 			newAuthor[i] = fixAffiliations(newAuthor[i])
 
-			newAuthor[i]['correspondence'] = newAuthor[i]['email'] if newAuthor[i].key?('email')
-			if newAuthor[i].key?('correspondence')
-				correspondenceList.push(newAuthor[i]['name'] + ' <' + newAuthor[i]['correspondence'] + '>')
+			newAuthor[i]['email'] = newAuthor[i]['correspondence'] if newAuthor[i].key?('correspondence')
+			if newAuthor[i].key?('email')
+				correspondenceList.push(newAuthor[i]['name'] + ' <' + newAuthor[i]['email'] + '>')
 			end
 
 			if newAuthor[i].key?('equal_contributor')


### PR DESCRIPTION
The email and correspondence YAML labels used to have the same effect
and were normalised into the same pandoc label `correspondence`,
providing the author's email address. Now, both labels remain
available to make a distinction between a corresponding author with
her email address and email addresses for non-corresponding authors.
Only the corresponding author will carry the `correspondence` label
as well as the `email` label (copied from correspondence), whereas
other authors will only carry the `email` label (when provided).

This is a code breaking change. Where one originally would refer to
label `correspondence`, now refer to `email` to get the author's
email address.