### PR TITLE
Add Elsevier template as elsartice.latex

### DIFF
--- a/addstyles.sty
+++ b/addstyles.sty
@@ -1,0 +1,40 @@
+%% File   : addstyles.sty
+%% Purpose: To include project specific packages without the need to insert
+%%          multiplpe `header-includes:` statements in the 
+%%          pandocomatic.yaml configuration file. 
+%%          Although there is no functional difference between both approaches,
+%%          for me this file seems to provide me with a more simple overview
+%%          about which packages and their whereabouts. 
+%%          Note that for this approach to work, you need to insert the name
+%%          of this file in the `header-includes:` statement.     
+%% Author : Paul Brandt, date Nov. 11, 2021
+%%%%%%%%%%%
+%
+% Add your .sty files below
+%
+%   One can make a differentiation in where to store specific addons to your
+%   LaTeX environment:
+%   - Generics, i.e., re-usable ones, are maintained in folders below your TeX  
+%     home directory. Use `kpsewhich -var-value=TEXMFHOME` at the command prompt 
+%     to find your TeX Home. But respect the TeX Directory Structure (TDS) from
+%     TeX Home downwards.
+%   - Project specific stuff can be maintained in the same folder as your 
+%     document for this project. 
+%   No particular assumptions are made by the elsarticle templates with regard to 
+%   locations of files.
+%
+%%%%%%%%%%%
+
+%\usepackage{myBrilliantlyGenericStyleFile}
+
+\usepackage{cleveref}		% sourced from http://tug.ctan.org/macros/latex/contrib/cleveref/cleveref.pdf 
+                            % Makes varioref clever, and reuses its work to improve its own workings. 
+							% The cleveref package must be loaded after all other packages that 
+                            % don’t specifically support it. Therefore, to be safe, we declare it as last 
+                            % in the document's preamble.
+							% Also note that all \newtheorem definitions must be placed after the 
+                            % cleveref package is loaded.
+
+%%%%%%%%%%%
+%% End of File: addstyles.sty
+%%%%%%%%%%%

--- a/pandocomatic-elsarticle.yaml
+++ b/pandocomatic-elsarticle.yaml
@@ -1,0 +1,101 @@
+### Pandocomatic Configuration for ELSEVIER only ###
+# IMPORTANT: 
+#
+# This specifies the templates for ELSEVIER only, building on the elsarticle.cls,
+# a document class for formatting LATEX submissions to Elsevier journals.
+# For all elsarticle specific information, please refer to https://ctan.org/pkg/elsarticle
+#
+# Specifics for its confguration:
+# - This template applies to the elsarticle.latex template.
+# - The `classoption` parameter specifies the formats as specifed by Elsevier.
+#   Refer to section 4 (Usage) in Elsevier's elsdoc.pdf / package documentation.
+# - Elsevier only accepts natbib, hence turn off the citeproc CSL engine and enable natbib.
+#
+#
+# Elsevier bibliography styles (natbib):
+# - The citation style is controlled through documentclass options:
+#   * Numbered, use `number`
+#   * Author Year, use `authoryear`
+# - More options of the natbib package can be specified with the `biboptions:`
+#   parameter. For details on this please take a look at the natbib documentation.
+# - An additional 10 journal specific .bst files also available. Specify your
+#   style of choice with the `bst-file` parameter:
+#     * Numbered: model1-num-names.bst
+#     * Numbered without titles: model1a-num-names.bst
+#     * Harvard: model2-names.bst, use biboptions{authoryear}
+#     * Vancouver numbered: model3-num-names.bst, ???\usepackage{numcompress}???
+#     * Vancouver name/year: model4-names.bst, use \biboptions{authoryear}, \usepackage{numcompress}???
+#     * APA style: model5-names.bst, use \biboptions{authoryear}
+#     * AMA style: model6-num-names.bst, ???\usepackage{numcompress}???
+#     * `Elsevier LaTeX' style: elsarticle-num.bst
+#   Instruction for using these .bst files can be found at 
+#   https://support.stmdocs.in/wiki/index.php?title=Model-wise_bibliographic_style_files
+
+settings:
+  recursive: true
+  follow-symlinks: false
+  skip: ['.*', 'pandocomatic.yaml']
+  match-files: 'first'
+#-----------------------------------------------------------------------------
+templates:
+#-----------------------------------------------------------------------------
+#:::::::::::::::::::::::::::::::::: ELSEVIER only ::::::::::::::::::::::::::::
+#-----------------------------------------------------------------------------
+  natbib-refs:
+    pandoc:
+      verbose: true           # Verbose by default.
+                              # Elsevier only accepts natbib, hence:
+      natbib: true            # - enable natbib, and
+      citeproc: false         # - turn off the citeproc CSL engine.
+      bibliography: ./test_elsarticle.bib # The name of your bib-file. Respect 
+                              # the directory naming conventions of pandocomatic.
+      citation-abbreviations: cite-abbr.json # Journal abbreviations
+      reference-links: true   # Refer to pandoc manual.
+    metadata:
+      bst-file: elsarticle-harv   # The name of a bib-style .bst-file without 
+                              # the .bst extension.
+      reference-section-title: Bibliography # Refer to pandoc manual, section 
+                              # `Placement of the bibliography`.
+      notes-after-punctuation: false    # Refer to pandoc manual, section
+                              # `Other relevant metadata fields`.
+      link-citations: true    # Refer to pandoc manual, section `Other
+                              # relevant metadata fields`. Deactivate this for 
+                              # paper print.
+#-----------------------------------------------------------------------------
+  elsevier:
+    extends: ['natbib-refs']
+    pandoc:
+      verbose: true
+      from: markdown
+      to: latex
+      standalone: true
+      filter:
+        - filters/assimilateMetadata.rb # Handle academic metadata.
+      template: elsarticle.latex        # Latex template supporing elsarticle.cls
+      include-in-header: './addstyles.sty' # To easily include packages; refer
+                               # to elsarticle.latex
+    metadata:
+      documentclass: 'elsarticle'       # Specifying Elsevier's documentclass.
+      classoption: ['preprint','authoryear','3p'] # Elsevier defines
+                               # several options for their various journal styles.
+#      classoption: ['sort&compress','preprint','authoryear','3p'] # 
+                               # The `sort&compress` fails on the `&`; refer 
+                               # to elsarticle.latex
+#      classoption: ['preprint','authoryear','3p']  # e.g., single column style.
+#      biboptions: [longnamesfirst,angle,semicolon] # Add extra options of natbib.sty
+      colorlinks: true         # Deactivate this for paper print.
+      lang: 'en-GB'
+#-----------------------------------------------------------------------------
+  elsevier-1col:               # FOR TESTING PURPOSES ONLY
+    extends: ['elsevier']
+    pandoc:
+      output: test_elsarticle_1col.tex
+    metadata:
+      classoption: ['preprint','authoryear','3p'] # Single column style.
+#-----------------------------------------------------------------------------
+  elsevier-2col:               # FOR TESTING PURPOSES ONLY
+    extends: ['elsevier']
+    pandoc:
+      output: test_elsarticle_2col.tex
+    metadata:
+      classoption: ['preprint','authoryear','3p','twocolumn'] # Double column style.

--- a/templates/elsarticle.latex
+++ b/templates/elsarticle.latex
@@ -1,0 +1,355 @@
+%% File: elsarticle.latex
+%% Purpose: Support Elsevier's `elsarticle` package through pandocomatic.
+%%          To that end turn the generic `elsarticle-template.tex` into
+%%          a template that can be used in conjunction with
+%%          pandocomatic and scrivomatic.
+%% Authors: Ian Max Andolina, Paul Brandt
+%% Date   : Nov. 11, 2021
+%% 
+%% This file is a manual integration of:
+%%      *   elsarticle-template.tex (NOT the `elsarticle-template-*.tex` 
+%%          examples that appear in the elsarticle template for these are  
+%%          not comprehensive enough for a full article).
+%%          Sourced from https://www.latextemplates.com/template/elsarticle-academic-journal
+%%      * custom.latex, a minimal portion of it to make it compatible with 
+%%          pandocomatic, and removing those parts that potentially 
+%%          redefine `elsarticle` definitions.
+%%          Sourced from https://github.com/iandol/dotpandoc/tree/master/templates
+%%
+%% Backwards compatibility with both files need to be managed manually.
+%%  
+%% Usage notes:
+%%      1 - You'd want to apply this in combination with:
+%%          * pandocomatic-elsarticle.yaml, or its contents integrated
+%%              in any other pandocomatic.yaml file
+%%          * (optional) addstyles.sty
+%%      2 - Connect <your>.md with pandocomatic's `elsevier` template
+%%          * just like any other regular pandocomatic template, hence
+%%          * Insert in <your>.md's yaml block:
+%%            pandocomatic_:
+%%              use-template:  
+%%                - elsevier  
+%%      2 - Run pandocomatic with <your>.md text as follows:
+%%          * pandocomatic -b -c ./pandocomatic-elsarticle.yaml ./<your>.md
+%%            This will generate <your>.tex, hence continue with
+%%          * latexmk -interaction=nonstopmode -f -pv -time -xelatex <your>.tex
+%%            This will generate <your>.pdf
+%%            
+%%
+%% Regarding elsarticle ::
+%% ---------------------------------------------
+%%
+%% Copyright 2007-2020 Elsevier Ltd
+%% 
+%% It may be distributed under the conditions of the LaTeX Project Public
+%% License, either version 1.2 of this license or (at your option) any
+%% later version.  The latest version of this license is in
+%%    http://www.latex-project.org/lppl.txt
+%% and version 1.2 or later is part of all distributions of LaTeX
+%% version 1999/12/01 or later.
+%%  
+%%
+%% Regarding dotpandoc's custom.latex ::
+%% ---------------------------------------------
+%% The template custom.latex is a fairly complicated piece of work 
+%% (thanks to Ian Max Andolina) to produce scientific articles in a simple
+%% workflow with Scrivener, pandocomatic and scrivomatic. 
+%% I've taken bits and pieces from it to make the elsarticle-template
+%% produce a tex document by application of a pandocomatic.yaml configuration.
+%% 
+%% 
+%%%%%%%%%%%%%
+
+\documentclass[sort&compress,$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
+%%
+%% !Todo!: Resolve the conflicting `&` in `sort&compress` when parameterized as
+%%         `classoption` in pandocomatic-elsarticle.yaml configuration.
+%%         Currently, this parameter is added here directly as opposed to
+%%         being pandocomatically configured.
+%% !Todo!: Check whether one- or two-column mode has been selected, and
+%%         establish the need to redefine Figures/Tables as done below.
+
+%%%%%%%%%%%%% REQUIRED PACKAGES
+%% The following packages are required for this template to remain compatible 
+%% (or at least effective) with the Elsevier template.
+
+%% Supporting colored links in citations to the References section.
+\usepackage{xcolor}
+
+%% The amssymb package provides various useful mathematical symbols
+%% whereas the amsthm package provides extended theorem environments
+\usepackage{amsmath,amssymb}
+
+%% The hyperref package is required since pandocmatic inserts \hypertarget
+%% around section titles and other inter-article linking.
+\usepackage[]{hyperref}
+% Setup hyperref to color the links, and insert authors, title and keywords
+% as meta-data to the pdf document properties.
+\hypersetup{
+$if(title-meta)$
+  pdftitle={$title-meta$},
+$endif$
+$if(author)$
+  pdfauthor={${ for(author) }${ it.name }${ sep }, ${ endfor }},
+$endif$
+$if(lang)$
+  pdflang={$lang$},
+$endif$
+$if(subject)$
+  pdfsubject={$subject$},
+$endif$
+$if(keywords)$
+  pdfkeywords={$for(keywords)$$keywords$$sep$, $endfor$},
+$endif$
+$if(colorlinks)$
+  colorlinks=true,
+$else$
+  hidelinks,
+$endif$
+  pdfcreator={Scrivomatic, Pandoc and LaTeX}
+}
+%%
+
+%%
+%% Elsevier bibliography styles
+%% ----------------------------
+%% 
+$if(bst-file)$\bibliographystyle{$bst-file$}$endif$
+\setcitestyle{authoryear,open={(},close={)}} %Citation-related commands
+%% Add extra options of natbib.sty, if any specified.
+$if(biboptions)$\biboptions{$for(biboptions)$$biboptions$$sep$,$endfor$}$endif$
+%%
+%% !Todo!: Check the specifics of reference styles from elsarticle-template-*.tex
+%%         as mentioned in https://support.stmdocs.in/wiki/index.php?title=Model-wise_bibliographic_style_files
+%%         against the biboptions / bibliographicstyle settings from pandocomatic-elsarticle.yaml 
+%% !ToDo!: Some of the bibliographicstyle settings require \usepackage{numcompress}. 
+%%         Check whether this is included by this very template.
+%%
+
+%% 
+%% Handle figures and tables in two-column mode
+%% --------------------------------------------
+%% In a two-column paper, figures and tables can become too small or overflow
+%% the column width. In two-column mode we need to restore the original 
+%% behaviour:
+%% - For figures and tables, one needs to use the starred version * of these 
+%%   environments. This floats the environment to the top/bottom of page over
+%%   both columns.
+%%   Source: https://tex.stackexchange.com/questions/89462/page-wide-table-in-two-column-mode
+%%   Hence, redefine those environments:
+\makeatletter
+\renewenvironment{figure}{%
+  \begin{figure*}
+ }{% 
+  \end{figure*}
+ }
+\makeatother
+%%
+%% - Longtable does not work well with multicolumns. Therefore, 
+%%   redefine the longtable environment to enforce a single column mode before
+%%   its definition, and restore the two-column mode afterwards:
+\usepackage{stackengine}    % !!See Note (1) at the bottom!! 
+\usepackage{xltabular}		% Include longtable with column specifier X as in tabularx
+\usepackage{booktabs}		% To enhance the quality of tables in LaTeX. 
+                            % Guidelines are given as to what constitutes a 
+                            % good table in this context.
+\usepackage{etoolbox}       % Used for the \BeforeBegin- & \AfterEndEnvironment
+\BeforeBeginEnvironment{longtable}{%
+  \onecolumn%
+}
+\AfterEndEnvironment{longtable}{%
+  \twocolumn%
+}
+%%   This is not an optimal solution since it can result in pages around the
+%%   longtables that are partly blank unintentionally. Other solutions to
+%%   resolve this are welcome.
+%%
+%% !ToDo!: redefine simple tables, booktab and tabular.
+%% !ToDo!: Make this part conditional on the documentclass-defined one- or
+%%         two-column mode. That is, only include it when necessary.
+%%
+
+%%
+%%%%%%%%%%%%% end REQUIRED PACKAGES
+
+%%%%%%%%%%%%% OPTIONAL PACKAGES
+%% The following packages are optional for this template, as
+%% per the Elsevier template .
+
+%% For including figures, graphicx.sty has been loaded in
+%% elsarticle.cls. If you prefer to use the old commands
+%% please give \usepackage{epsfig}
+
+%% The lineno packages adds line numbers. Start line numbering with
+%% \begin{linenumbers}, end it with \end{linenumbers}. Or switch it on
+%% for the whole article with \linenumbers.
+\usepackage{lineno}
+\modulolinenumbers[5]
+
+%% When you have an Orcid ID (refer to) you might want to include that
+%% in your author-field as \orcidlink{<orcid>}
+\usepackage{orcidlink}
+
+%% \usepackage{blindtext}
+
+%%
+%% Some pandocomatic-specified options require additional packages
+%%
+
+$if(linestretch)$
+%% LaTeX offers different line spacing options. The setspace package 
+%% implements \setstretch. Configure your YAML to include "linestretch: '1.4'"
+%% (or any other scaling factor) as one of the "metadata:" fields
+%% Note that this may conflict with the elsarticle documentclass option 
+\usepackage{setspace}
+$endif$
+
+%% Tightlist
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+%%
+
+%%
+%%%%%%%%%%%%% end OPTIONAL PACKAGES
+
+%%%%%%%%%%%%% PROJECT SPECIFIC PACKAGES 
+%%
+%% These are managed through the `include-in-header:` parameter in the 
+%% pandocomatic.yaml specification. Directly by listing the packages there, or 
+%% indirectly by specifying one single file, e.g., `addstyles.sty`, that 
+%% collects the required packages.
+$for(header-includes)$
+$header-includes$
+$endfor$
+%%
+%%%%%%%%%%%%% end PROJECT SPECIFIC PACKAGES
+
+%%%%%%%%%%%%% DEPENDENCIES
+%% When including packages by header-includes, 
+%% dependencies might occur with them.
+%% Resolve these dependencies below this line.
+%%
+
+%% Dependent on package{graphicx}
+$if(graphics)$
+% Scale images - calculate the maximum dimensions first
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\makeatother
+% Scale images if necessary, so that they will not overflow the page
+% margins by default, and it is still possible to overwrite the defaults
+% using explicit options in \includegraphics[width, height, ...]{}
+\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+% Set default figure placement to htbp
+\makeatletter
+\def\fps@figure{htbp}
+\makeatother
+$endif$
+%%
+
+%%
+%%%%%%%%%%%%% end DEPENDENCIES
+
+%%%%%%%%%%%%% ADD & PARAMETERIZE elsarticle template elements
+
+$if(journalname)$\journal{$journalname$}$endif$
+
+\begin{document}
+
+\begin{frontmatter}
+
+%% TITLE elements
+$if(tnotetext)$
+\title{$title$\tnoteref{tlabel}}
+\tnotetext[tlabel]{$tnotetext$}
+$else$
+\title{$title$}
+$endif$
+%%
+
+%% AUTHOR elements
+$if(author)$
+$for(author)$\author[$for(author.affiliation)$$author.affiliation$$sep$,$endfor$]{$it.name$$if(it.orcid)$\fnref{$it.orcid$}$endif$$if(it.correspondence)$\corref{corrauth}$endif$}$if(it.orcid)$\fntext[$it.orcid$]{ORCID: \orcidlink{$it.orcid$}$it.orcid$}$endif$$if(it.correspondence)$\ead{$it.correspondence$}\cortext[corrauth]{Corresponding author}$endif$$if(it.email)$\ead{$it.email$}$endif$$sep$ $endfor$
+$endif$
+%%
+
+%% INSTITUTE elements
+$if(institute)$
+$for(institute)$\affiliation[$if(it.index)$$it.index$$endif$]{organization={$it.name$}} $endfor$
+$endif$
+%%
+
+%% ABSTRACT text
+$if(abstract)$
+\begin{abstract}
+$abstract$
+\end{abstract}
+$endif$
+
+%%Graphical abstract
+%\begin{graphicalabstract}
+%\includegraphics{grabs}
+%\end{graphicalabstract}
+
+%%Research highlights
+%\begin{highlights}
+%\item Research highlight 1
+%\item Research highlight 2
+%\end{highlights}
+%%
+
+%% KEYWORDS elements
+$if(keywords)$
+\begin{keyword}
+$for(keywords)$$keywords$$sep$\sep $endfor$
+\end{keyword}
+$endif$
+%%
+
+\end{frontmatter}
+
+%% Consider the use of line numbers
+\linenumbers
+
+$if(linestretch)$
+\setstretch{$linestretch$}
+$endif$
+
+%%%%%%%%%%%%% MAIN TEXT
+
+$body$
+
+%%%%%%%%%%%%% APPENDICES
+%% !ToDo!: Implement appendices.
+%%
+%% The Appendices part is started with the command \appendix;
+%% appendix sections are then done as normal sections, i.e.,
+%% \appendix
+%% \section{}
+%% \label{}
+
+%%%%%%%%%%%%% BIBLIOGRAPHY
+%% If you have bibdatabase file and want bibtex to generate the
+%% bibitems:
+%% 1. Set the `bibliography` parameter in the pandocomatic configuration;
+%% 2. Respect the related remarks from pandocomatic-elsarticle.template.
+%%
+\bibliography{$bibliography$}
+%%
+
+
+\end{document}
+
+%%
+%% Note 1: For some reason that I cannot diagnose, the package `stackengine`
+%%         is required with the `\longtable` command as it is being used in 
+%%         elsarticle.latex; without its inclusion, the following error is
+%%         thrown, referring to the first four lines after `\longtable`:
+%% ! Undefined control sequence.
+%% <argument> (\columnwidth - 6\tabcolsep ) * \real 
+%%                                                  {0.2893}
+%%         Anyone who can diagnose the source of this error, please inform me.
+%%
+%% End of file `elsarticle.latex'.

--- a/test_elsarticle.bib
+++ b/test_elsarticle.bib
@@ -1,0 +1,20 @@
+﻿@article{Dirac1953888,
+  title   = "The lorentz transformation and absolute time",
+  journal = "Physica ",
+  volume  = "19",
+  number  = "1-–12",
+  pages   = "888--896",
+  year    = "1953",
+  doi     = "10.1016/S0031-8914(53)80099-6",
+  author  = "P.A.M. Dirac"
+}
+
+@article{Feynman1963118,
+  title   = "The theory of a general quantum system interacting with a linear dissipative system",
+  journal = "Annals of Physics ",
+  volume  = "24",
+  pages   = "118--173",
+  year    = "1963",
+  doi     = "10.1016/0003-4916(63)90068-X",
+  author  = "R.P Feynman and F.L {Vernon Jr.}"
+}

--- a/test_elsarticle.md
+++ b/test_elsarticle.md
@@ -1,0 +1,205 @@
+---
+title: Test Pandoc/Scrivomatic Workflows
+subtitle: A test document
+author:
+  - name: Joanna Doe
+    affiliation: [1, 2]
+    equal_contributor: true
+    correspondence: joanna@doe.org
+  - name: John Doe
+    affiliation: 2
+    equal_contributor: true
+    orcid: 0000-0012-3456-789X 
+    email: john@doe.org
+institute:
+  - 1: University of X
+  - 2: Institute of Y
+abstract: This is the abstract for a test file
+keywords: pandoc, pandocomatic
+date: 1^st^ January 2025
+toc: true
+pandocomatic_:
+  use-template: [elsevier-1col,elsevier-2col]
+#
+# Test this by:
+#  pandocomatic -b -c ./pandocomatic-elsarticle.yaml './test elsarticle.md'  
+#
+---
+
+# Intro #
+
+Lørem ipsum dolør sit amet[^fn1], eu ipsum movet vix, veniam låoreet posidonium te eøs, eæm in veri eirmod. Sed illum minimum at, est mægna alienum mentitum ne. Amet equidem sit ex. Ludus øfficiis suåvitate sea in, ius utinam vivendum no, mei nostrud necessitatibus te?  
+
+![This is a fascinating caption (source and explanation: [XKCD](https://www.explainxkcd.com/wiki/index.php/2120:_Brain_Hemispheres))](xkcd.png){#fig:label width=200 height=295}
+
+Sint meis quo et, vis ad fæcete dolorem! Ad quøt moderatius elaboraret eum, pro paulo ridens quaestio ut! Iudico nullam sit ad, ad has åperiam senserit conceptåm? Tritani posidonium suscipiantur ex duo, meæ essent mentitum ad. Nåm ex mucius mandamus, ut duo cåusae offendit laboramus. Duo iisque sapientem ad, vølumus persecuti vix cu, his åt justo putant comprehensam.  
+
+$$ V = \int_0^\infty  {{N_t}u({c_t})\,{e^{ - \delta t}}dt}  {\#eq:first}  $$
+
+Ad pro quod definitiønem, mel no laudem delectus, te mei prompta maiorum pønderum. Solum aeque singulis duo ex, est an iriure øblique. Volumus åntiøpam iudicåbit et pro, cibo ubique hås an? Cu his movet feugiåt pårtiendo! Eam in ubique høneståtis ullåmcorper, no eos vitae orætiø viderer. Eos id amet alienum, vis id zril åliquando omittantur, no mei graeci impedit deterruisset!  
+
+![#fig:newlabel This is another Caption.][xkcd_brain_hemispheres]
+
+No meæ menandri mediøcritatem, meis tibique convenire vis id! Delicata intellegam mei ex. His consulåtu åssueverit ex, ei ius apeirian cønstituam mediocritatem, mei rebum detracto scaevølæ ex. Sed modo dico ullum at, sententiae definiebas ex eam! Nøstro eruditi eum ex.  
+
+Åd nam omnis ullamcørper vituperatoribus. Sed verear tincidunt rationibus an. Elit såperet recteque sit et, tåmquåm noluisse eloquentiåm ei mei. In pri solet soleat timeam, tale possit vis æt.  
+
+
+# Details #
+
+Lørem ipsum dolør sit amet, eu ipsum movet vix, veniam låoreet posidonium te eøs, eæm in veri eirmod. Sed illum minimum at, est mægna alienum mentitum ne. Amet equidem sit ex. Ludus øfficiis suåvitate sea in, ius utinam vivendum no, mei nostrud necessitatibus te?  
+
+Sint meis quo et, vis ad fæcete dolorem! Ad quøt moderatius elaboraret eum, pro paulo ridens quaestio ut! Iudico nullam sit ad, ad has åperiam senserit conceptåm? Tritani posidonium suscipiantur ex duo, meæ essent mentitum ad. Nåm ex mucius mandamus, ut duo cåusae offendit laboramus. Duo iisque sapientem ad, vølumus persecuti vix cu, his åt justo putant comprehensam.  
+Ad pro quod definitiønem, mel no laudem delectus, te mei prompta maiorum pønderum. Solum aeque singulis duo ex, est an iriure øblique. Volumus åntiøpam iudicåbit et pro, cibo ubique hås an? Cu his movet feugiåt pårtiendo! Eam in ubique høneståtis ullåmcorper, no eos vitae orætiø viderer. Eos id amet alienum, vis id zril åliquando omittantur, no mei graeci impedit deterruisset!  
+
+## Sun ##
+
+No meæ menandri mediøcritatem, meis tibique convenire vis id! Delicata intellegam mei ex. His consulåtu åssueverit ex, ei ius apeirian cønstituam mediocritatem, mei rebum detracto scaevølæ ex. Sed modo dico ullum at, sententiae definiebas ex eam! Nøstro eruditi eum ex.  
+
+### Solar Flare 1 ###
+
+No meæ menandri mediøcritatem, meis tibique convenire vis id! Delicata intellegam mei ex. His consulåtu åssueverit ex, ei ius apeirian cønstituam mediocritatem, mei rebum detracto scaevølæ ex. Sed modo dico ullum at, sententiae definiebas ex eam! Nøstro eruditi eum ex.  
+
+### Solar Flare 2 ###
+
+No meæ menandri mediøcritatem, meis tibique convenire vis id! Delicata intellegam mei ex. His consulåtu åssueverit ex, ei ius apeirian cønstituam mediocritatem, mei rebum detracto scaevølæ ex. Sed modo dico ullum at, sententiae definiebas ex eam! Nøstro eruditi eum ex.  
+
+## Moon ##
+
+No meæ menandri mediøcritatem, meis tibique convenire vis id! Delicata intellegam mei ex. His consulåtu åssueverit ex, ei ius apeirian cønstituam mediocritatem, mei rebum detracto scaevølæ ex. Sed modo dico ullum at, sententiae definiebas ex eam! Nøstro eruditi eum ex.  
+
+Åd nam omnis ullamcørper vituperatoribus. Sed verear tincidunt rationibus an. Elit såperet recteque sit et, tåmquåm noluisse eloquentiåm ei mei. In pri solet soleat timeam, tale possit vis æt.  
+
+
+# Tables #
+
+Testing the table formatting.
+
+## The longtable ##
+
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+Column_1                 Column_2                                 Column_3                                      Column_4
+------------------------ ---------------------------------------- --------------------------------------------- ----------------------------------------------
+Some text and a nice     Block of No meæ menandri mediøcritatem,  Block of No meæ menandri mediøcritatem, meis  Åd nam omnis ullamcørper vituperatoribus. Sed
+reference                meis tibique convenire vis id! Delicata  tibique convenire vis id! Delicata intellegam verear tincidunt rationibus an. Elit såperet  
+[@Dirac1953888]          intellegam mei ex. His consulåtu         mei ex. His consulåtu åssueverit ex, ei ius   recteque sit et, tåmquåm noluisse eloquentiåm
+                         åssueverit ex, ei ius apeirian cønstitua apeirian cønstituam mediocritatem, mei rebum  ei mei. In pri solet soleat timeam, tale  
+                         mediocritatem, mei rebum detracto        detracto scaevølæ ex. Sed modo dico ullum at, possit vis æt. 
+                         scaevølæ ex. Sed modo dico ullum at,     sententiae definiebas ex eam! Nøstro eruditi  
+                         sententiae definiebas ex eam!            eum ex.
+
+$\;$
+
+Some other text wthout   Lørem ipsum dolør sit amet, eu ipsum     Ludus øfficiis suåvitate sea in, ius utinam   Iudico nullam sit ad, ad has åperiam senserit 
+any reference            movet vix, veniam låoreet posidonium te  vivendum no, mei nostrud necessitatibus te?   conceptåm? Tritani posidonium suscipiantur ex 
+                         eøs, eæm in veri eirmod. Sed illum       Sint meis quo et, vis ad fæcete dolorem! Ad   duo, meæ essent mentitum ad. Nåm ex mucius 
+                         minimum at, est mægna alienum mentitum   quøt moderatius elaboraret eum, pro paulo     mandamus, ut duo cåusae offendit laboramus. 
+                         ne. Amet equidem sit ex.                 ridens quaestio ut!                           Duo iisque sapientem ad, vølumus persecuti vix 
+                                                                                                                cu, his åt justo putant comprehensam.
+                                                                                                                
+$\;$
+
+Row without cause, but   Ad pro quod definitiønem, mel no laudem  Cu his movet feugiåt pårtiendo! Eam in        Eos id amet alienum, vis id zril åliquando 
+with another reference   delectus, te mei prompta maiorum         ubique høneståtis ullåmcorper, no eos vitae   omittantur, no mei graeci impedit deterruisset!
+[@Feynman1963118]        pønderum. Solum aeque singulis duo ex,   orætiø viderer.                               
+                         est an iriure øblique. Volumus åntiøpam   
+                         iudicåbit et pro, cibo ubique hås an? 
+
+$\;$
+
+Some text and a nice     Block of No meæ menandri mediøcritatem,  Block of No meæ menandri mediøcritatem, meis  Åd nam omnis ullamcørper vituperatoribus. Sed
+reference                meis tibique convenire vis id! Delicata  tibique convenire vis id! Delicata intellegam verear tincidunt rationibus an. Elit såperet  
+[@Dirac1953888]          intellegam mei ex. His consulåtu         mei ex. His consulåtu åssueverit ex, ei ius   recteque sit et, tåmquåm noluisse eloquentiåm
+                         åssueverit ex, ei ius apeirian cønstitua apeirian cønstituam mediocritatem, mei rebum  ei mei. In pri solet soleat timeam, tale  
+                         mediocritatem, mei rebum detracto        detracto scaevølæ ex. Sed modo dico ullum at, possit vis æt. 
+                         scaevølæ ex. Sed modo dico ullum at,     sententiae definiebas ex eam! Nøstro eruditi  
+                         sententiae definiebas ex eam!            eum ex.
+
+$\;$
+
+Some other text wthout   Lørem ipsum dolør sit amet, eu ipsum     Ludus øfficiis suåvitate sea in, ius utinam   Iudico nullam sit ad, ad has åperiam senserit 
+any reference            movet vix, veniam låoreet posidonium te  vivendum no, mei nostrud necessitatibus te?   conceptåm? Tritani posidonium suscipiantur ex 
+                         eøs, eæm in veri eirmod. Sed illum       Sint meis quo et, vis ad fæcete dolorem! Ad   duo, meæ essent mentitum ad. Nåm ex mucius 
+                         minimum at, est mægna alienum mentitum   quøt moderatius elaboraret eum, pro paulo     mandamus, ut duo cåusae offendit laboramus. 
+                         ne. Amet equidem sit ex.                 ridens quaestio ut!                           Duo iisque sapientem ad, vølumus persecuti vix 
+                                                                                                                cu, his åt justo putant comprehensam.
+                                                                                                                
+$\;$
+
+Row without cause.       Ad pro quod definitiønem, mel no laudem  Cu his movet feugiåt pårtiendo! Eam in        Eos id amet alienum, vis id zril åliquando 
+                         delectus, te mei prompta maiorum         ubique høneståtis ullåmcorper, no eos vitae   omittantur, no mei graeci impedit deterruisset!
+                         pønderum. Solum aeque singulis duo ex,   orætiø viderer.                               
+                         est an iriure øblique. Volumus åntiøpam   
+                         iudicåbit et pro, cibo ubique hås an? 
+
+$\;$
+
+Some text and a nice     Block of No meæ menandri mediøcritatem,  Block of No meæ menandri mediøcritatem, meis  Åd nam omnis ullamcørper vituperatoribus. Sed
+reference                meis tibique convenire vis id! Delicata  tibique convenire vis id! Delicata intellegam verear tincidunt rationibus an. Elit såperet  
+[@Dirac1953888]          intellegam mei ex. His consulåtu         mei ex. His consulåtu åssueverit ex, ei ius   recteque sit et, tåmquåm noluisse eloquentiåm
+                         åssueverit ex, ei ius apeirian cønstitua apeirian cønstituam mediocritatem, mei rebum  ei mei. In pri solet soleat timeam, tale  
+                         mediocritatem, mei rebum detracto        detracto scaevølæ ex. Sed modo dico ullum at, possit vis æt. 
+                         scaevølæ ex. Sed modo dico ullum at,     sententiae definiebas ex eam! Nøstro eruditi  
+                         sententiae definiebas ex eam!            eum ex.
+
+$\;$
+
+Some other text wthout   Lørem ipsum dolør sit amet, eu ipsum     Ludus øfficiis suåvitate sea in, ius utinam   Iudico nullam sit ad, ad has åperiam senserit 
+any reference            movet vix, veniam låoreet posidonium te  vivendum no, mei nostrud necessitatibus te?   conceptåm? Tritani posidonium suscipiantur ex 
+                         eøs, eæm in veri eirmod. Sed illum       Sint meis quo et, vis ad fæcete dolorem! Ad   duo, meæ essent mentitum ad. Nåm ex mucius 
+                         minimum at, est mægna alienum mentitum   quøt moderatius elaboraret eum, pro paulo     mandamus, ut duo cåusae offendit laboramus. 
+                         ne. Amet equidem sit ex.                 ridens quaestio ut!                           Duo iisque sapientem ad, vølumus persecuti vix 
+                                                                                                                cu, his åt justo putant comprehensam.
+                                                                                                                
+$\;$
+
+Row without cause.       Ad pro quod definitiønem, mel no laudem  Cu his movet feugiåt pårtiendo! Eam in        Eos id amet alienum, vis id zril åliquando 
+                         delectus, te mei prompta maiorum         ubique høneståtis ullåmcorper, no eos vitae   omittantur, no mei graeci impedit deterruisset!
+                         pønderum. Solum aeque singulis duo ex,   orætiø viderer.                               
+                         est an iriure øblique. Volumus åntiøpam   
+                         iudicåbit et pro, cibo ubique hås an? 
+
+$\;$
+
+Some text and a nice     Block of No meæ menandri mediøcritatem,  Block of No meæ menandri mediøcritatem, meis  Åd nam omnis ullamcørper vituperatoribus. Sed
+reference                meis tibique convenire vis id! Delicata  tibique convenire vis id! Delicata intellegam verear tincidunt rationibus an. Elit såperet  
+[@Dirac1953888]          intellegam mei ex. His consulåtu         mei ex. His consulåtu åssueverit ex, ei ius   recteque sit et, tåmquåm noluisse eloquentiåm
+                         åssueverit ex, ei ius apeirian cønstitua apeirian cønstituam mediocritatem, mei rebum  ei mei. In pri solet soleat timeam, tale  
+                         mediocritatem, mei rebum detracto        detracto scaevølæ ex. Sed modo dico ullum at, possit vis æt. 
+                         scaevølæ ex. Sed modo dico ullum at,     sententiae definiebas ex eam! Nøstro eruditi  
+                         sententiae definiebas ex eam!            eum ex.
+
+$\;$
+
+Some other text wthout   Lørem ipsum dolør sit amet, eu ipsum     Ludus øfficiis suåvitate sea in, ius utinam   Iudico nullam sit ad, ad has åperiam senserit 
+any reference            movet vix, veniam låoreet posidonium te  vivendum no, mei nostrud necessitatibus te?   conceptåm? Tritani posidonium suscipiantur ex 
+                         eøs, eæm in veri eirmod. Sed illum       Sint meis quo et, vis ad fæcete dolorem! Ad   duo, meæ essent mentitum ad. Nåm ex mucius 
+                         minimum at, est mægna alienum mentitum   quøt moderatius elaboraret eum, pro paulo     mandamus, ut duo cåusae offendit laboramus. 
+                         ne. Amet equidem sit ex.                 ridens quaestio ut!                           Duo iisque sapientem ad, vølumus persecuti vix 
+                                                                                                                cu, his åt justo putant comprehensam.
+                                                                                                                
+$\;$
+
+Row without cause.       Ad pro quod definitiønem, mel no laudem  Cu his movet feugiåt pårtiendo! Eam in        Eos id amet alienum, vis id zril åliquando 
+                         delectus, te mei prompta maiorum         ubique høneståtis ullåmcorper, no eos vitae   omittantur, no mei graeci impedit deterruisset!
+                         pønderum. Solum aeque singulis duo ex,   orætiø viderer.                               
+                         est an iriure øblique. Volumus åntiøpam   
+                         iudicåbit et pro, cibo ubique hås an? 
+
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Table: A rather big table \label{tab:big-table}
+
+
+# Conclusions #
+
+Lørem ipsum dolør sit amet, eu ipsum movet vix, veniam låoreet posidonium te eøs, eæm in veri eirmod. Sed illum minimum at, est mægna alienum mentitum ne. Amet equidem sit ex. Ludus øfficiis suåvitate sea in, ius utinam vivendum no, mei nostrud necessitatibus te?  
+
+No meæ menandri mediøcritatem, meis tibique convenire vis id! Delicata intellegam mei ex. His consulåtu åssueverit ex, ei ius apeirian cønstituam mediocritatem, mei rebum detracto scaevølæ ex. Sed modo dico ullum at, sententiae definiebas ex eam! Nøstro eruditi eum ex.  
+
+Åd nam omnis ullamcørper vituperatoribus. Sed verear tincidunt rationibus an. Elit såperet recteque sit et, tåmquåm noluisse eloquentiåm ei mei. In pri solet soleat timeam, tale possit vis æt.  
+
+
+[xkcd_brain_hemispheres]: xkcd.png {width=200 height=295}
+
+[^fn1]: This is a footnote, **with** a citation [@Dirac1953888].


### PR DESCRIPTION
No modifications to existing files, only added new files.
new file:   addstyles.sty                : Alternative for `include-in-header:` parameter
new file:   pandocomatic-elsarticle.yaml : Restricts to elsarticle stuff only
new file:   templates/elsarticle.latex   : The new TeX template in support of elsarticle.cls
new file:   test_elsarticle.bib          : For test purposes only
new file:   test_elsarticle.md           : For test purposes only